### PR TITLE
feat: matplotlibからpyqtgraphへの移行

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sounddevice>=0.5.1
 numpy>=1.24.0
-matplotlib>=3.7.0
+pyqtgraph>=0.13.7
+PyQt5>=5.15.11
 scipy>=1.10.0


### PR DESCRIPTION
## 変更内容
- 描画エンジンをmatplotlibからpyqtgraphに置き換え
- 約60FPSの高速描画を実現
- グローエフェクトとフェードアウト機能を維持
- 依存関係を更新（matplotlib削除、pyqtgraphとPyQt5追加）
- 
- ## 関連Issue
- Closes #4